### PR TITLE
FreeBSD 13 support

### DIFF
--- a/lib.bash
+++ b/lib.bash
@@ -178,13 +178,22 @@ pool_state_color() {
   esac
 }
 
+# ZFS in FreeBSD 13 has changed slightly; `zpool status` does not
+# output a `scan` line unless a scrub has been requested.
 scrub_info() {
   local pool=$1
+  local info
 
-  zpool status "$pool" \
+  info=$( zpool status "$pool" \
     | grep -A 2 '^  scan: ' \
     | grep -E '(^        )|(scan: )' \
-    | sed -E 's/^.{8}//'
+    | sed -E 's/^.{8}//' )
+
+  if [[ -z "$info" ]]; then
+    echo "none requested"
+  else
+    echo "$info"
+  fi
 }
 
 get_all_zfs_pools() {

--- a/zfs_motd
+++ b/zfs_motd
@@ -3,11 +3,25 @@
 scriptdir=$( dirname "$0" )
 scriptdir=$( readlink -f "$scriptdir" )
 
+# Set FreeBSD version
+IFS='-' read -r -a freebsd_version < <( uname -r  )
+
+is_bsd_13=0
+if [[ "${freebsd_version[0]}" = *13* ]]; then
+  is_bsd_13=1
+fi
+
 pushd "$scriptdir" &> /dev/null
 
 . ./lib.bash
 
-motd_file=/etc/motd
+# If we're running FreeBSD >= 13,  we need to update a different file
+if (( is_bsd_13 )); then
+	motd_file=/etc/motd.template
+else
+	motd_file=/etc/motd
+fi
+
 motd_d_dir=${1:-/etc/motd.d}
 tail_outfile="$motd_d_dir/5_zfs_info"
 
@@ -17,3 +31,7 @@ storage_info > "$tail_outfile"
 
 create_motd "$motd_d_dir" "$motd_file"
 
+# If we're on FreeBSD 13, we now need to restart the motd service
+if (( is_bsd_13 )); then
+	service motd restart
+fi


### PR DESCRIPTION
* The MOTD file we need to update is now /etc/motd.template
* Added a motd service restart for FBSD13
* Changed scrub_info() to provide a default string, since FBSD13's `zpool status` doesn't always include `scan`.